### PR TITLE
Added build on FreeBSD without fdatasync() uses fsync()

### DIFF
--- a/sophia/rt/sr_file.c
+++ b/sophia/rt/sr_file.c
@@ -105,6 +105,8 @@ int sr_filesync(srfile *f)
 {
 #if defined(__APPLE__)
 	return fcntl(f->fd, F_FULLFSYNC);
+#elif defined(__FreeBSD__)
+	return fsync(f->fd);
 #else
 	return fdatasync(f->fd);
 #endif


### PR DESCRIPTION
FreeBSD doesn't support fdatasync() instead that need to use fsync().

```
[  3%] Generating third_party/sophia/libsophia.a
SOPHIA v1.2
cc: cc
cflags: -DSR_INJECTION_ENABLE -g -O0 -std=c99 -pedantic -Wextra -Wall

build
fatal: Not a git repository: ../../.git/modules/sophia
cc sophia.c
sophia/rt/sr_file.c:109:9: warning: implicit declaration of function 'fdatasync' is invalid in C99 [-Wimplicit-function-declaration]
        return fdatasync(f->fd);
               ^
1 warning generated.
ar libsophia.a
[  3%] Built target libsophia
```

```
../third_party/sophia/libsophia.a(sophia.o): In function `sr_filesync':
/home/vg/Develop/tarantool/build/third_party/sophia/sophia/rt/sr_file.c:109: undefined reference to `fdatasync'
CC: error: linker command failed with exit code 1 (use -v to see invocation)
```

Please merge and update sophia submodule.
